### PR TITLE
Object support

### DIFF
--- a/Slug.php
+++ b/Slug.php
@@ -132,6 +132,17 @@ class Slug
 				return $this->_check_uri($this->create_slug($data[$this->title]), $id);
 			}
 		}
+		elseif (is_object($data))
+		{
+			if ( ! empty($data->{$this->field}))
+			{
+				return $this->_check_uri($this->create_slug($data->{$this->field}), $id);
+			}
+			elseif ( ! empty($data->{$this->title}))
+			{
+				return $this->_check_uri($this->create_slug($data->{$this->title}), $id);
+			}
+		}
 		elseif (is_string($data))
 		{
 			return $this->_check_uri($this->create_slug($data), $id);

--- a/readme.md
+++ b/readme.md
@@ -107,14 +107,14 @@ $this->slug->create_uri($data, 1)
 
 ```php
 $data = (object)[];
-$data->title = 'My Test',
+$data->title = 'My Test';
 
 $this->slug->create_uri($data)
 ```
 
 ```php
 $data = (object)[];
-$data->title = 'My Test',
+$data->title = 'My Test';
 
 $this->slug->create_uri($data, 1)
 ```

--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ Creates the actual uri string and in the background validates against the table 
 
 **Paramaters**
 
-* $data - (requied) Array of data
+* $data - (requied) Array or object of data
 * $id - (optional) Id of current record
 
 ```php
@@ -102,6 +102,20 @@ $this->slug->create_uri($data)
 $data = array(
 	'title' => 'My Test',
 );
+$this->slug->create_uri($data, 1)
+```
+
+```php
+$data = (object)[];
+$data->title = 'My Test',
+
+$this->slug->create_uri($data)
+```
+
+```php
+$data = (object)[];
+$data->title = 'My Test',
+
 $this->slug->create_uri($data, 1)
 ```
 


### PR DESCRIPTION
Until now, `$data` could only be a string or an array.

Now, objects are supported as well.

For example, `$data` must contain `$data->title` (equivalent to `$data['title']` in an array).